### PR TITLE
Add basic try-on web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Wearly
+
+A simple web app that lets you try clothing on your own photo directly in the browser. Upload a user picture and a clothing item image, then drag and scale the clothing overlay.
+
+This project is designed to run on GitHub Pages. To test locally, open `index.html` in any modern browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wearly Try-On</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Wearly</h1>
+    <div id="uploader">
+        <label>User photo: <input type="file" id="user-upload" accept="image/*"></label>
+        <label>Clothing item: <input type="file" id="cloth-upload" accept="image/*"></label>
+        <label>Scale: <input type="range" id="scale" min="0.2" max="3" step="0.1" value="1"></label>
+    </div>
+    <div id="canvas-container">
+        <img id="user-img" alt="User preview" hidden>
+        <img id="cloth-img" alt="Clothing preview" hidden>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,49 @@
+const userUpload = document.getElementById('user-upload');
+const clothUpload = document.getElementById('cloth-upload');
+const userImg = document.getElementById('user-img');
+const clothImg = document.getElementById('cloth-img');
+const scaleInput = document.getElementById('scale');
+let dragging = false;
+let offsetX = 0;
+let offsetY = 0;
+
+userUpload.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) {
+    userImg.src = URL.createObjectURL(file);
+    userImg.hidden = false;
+  }
+});
+
+clothUpload.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) {
+    clothImg.src = URL.createObjectURL(file);
+    clothImg.hidden = false;
+    clothImg.style.left = '0px';
+    clothImg.style.top = '0px';
+    clothImg.style.transform = 'scale(1)';
+    scaleInput.value = 1;
+  }
+});
+
+clothImg.addEventListener('mousedown', e => {
+  dragging = true;
+  offsetX = e.offsetX;
+  offsetY = e.offsetY;
+});
+
+document.addEventListener('mousemove', e => {
+  if (!dragging) return;
+  const rect = document.getElementById('canvas-container').getBoundingClientRect();
+  clothImg.style.left = (e.clientX - rect.left - offsetX) + 'px';
+  clothImg.style.top = (e.clientY - rect.top - offsetY) + 'px';
+});
+
+document.addEventListener('mouseup', () => {
+  dragging = false;
+});
+
+scaleInput.addEventListener('input', e => {
+  clothImg.style.transform = `scale(${e.target.value})`;
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,25 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+#canvas-container {
+    position: relative;
+    margin-top: 20px;
+    width: 500px;
+    height: 600px;
+    border: 1px solid #ccc;
+    overflow: hidden;
+}
+#canvas-container img {
+    position: absolute;
+    max-width: none;
+    user-select: none;
+}
+#user-img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+#cloth-img {
+    cursor: move;
+}


### PR DESCRIPTION
## Summary
- create a simple client-only try-on app
- allow uploading a user photo and a clothing item
- overlay and drag the clothing
- document usage in README

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863bd54adf883209ca997dd3dfd74fb